### PR TITLE
devshell

### DIFF
--- a/NORTHWOOD.md
+++ b/NORTHWOOD.md
@@ -1,0 +1,31 @@
+# Northwood Altera Linux
+
+## Developer Environment
+```bash
+$ nix develop .#
+```
+
+This will drop you into a shell with all of the required tools to compile the Altera fork of the linux kernel.
+
+
+### menuconfig
+Uncomment out `# menuconfig = true` in the `flake.nix` and reenter your shell with `nix develop .#`
+
+### xconfig
+Uncomment out `# xconfig = true` in the `flake.nix` and reenter your shell with `nix develop .#`
+
+## Building
+Enter the shell and see supported aliases using just.
+
+```bash
+northwood@build4:~/linux-socfpga$ just
+Available recipes:
+    default     # Display this message
+
+    [Build]
+    build       # Build Linux Kernel Image for Northwood Beamformer
+    clean       # Removes build artifacts and generated configuration files
+    link-config # Link the nix-build generated linux config to .config
+    menuconfig  # Configure linux kernel parameters via menuconfig. You will need to be in the shell with menuconfig = true; in the flake.nix
+    xconfig     # Configure linux kernel parameters via xconfig. You will need to be in the shell with xconfig = true; in the flake.nix
+```

--- a/NORTHWOOD.md
+++ b/NORTHWOOD.md
@@ -1,5 +1,7 @@
 # Northwood Altera Linux
 
+See [Building Linux Kernel](https://www.rocketboards.org/foswiki/Documentation/BuildingBootloaderStratix10#Building_Linux_Kernel) from the Building Bootloader Stratix10 tutorial provided by Altera.
+
 ## Developer Environment
 ```bash
 $ nix develop .#

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,304 @@
+{
+  "nodes": {
+    "attic": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1738524606,
+        "narHash": "sha256-hPYEJ4juK3ph7kbjbvv7PlU1D9pAkkhl+pwx8fZY53U=",
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "ff8a897d1f4408ebbf4d45fa9049c06b3e1e3f4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "ff8a897d1f4408ebbf4d45fa9049c06b3e1e3f4e",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722960479,
+        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740485968,
+        "narHash": "sha256-WK+PZHbfDjLyveXAxpnrfagiFgZWaTJglewBWniTn2Y=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741701235,
+        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734083684,
+        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/314e12ba369ccdb9b352a4db26ff419f7c49fa84.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/314e12ba369ccdb9b352a4db26ff419f7c49fa84.tar.gz"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1724316499,
+        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "northwood-nixpkgs": {
+      "inputs": {
+        "attic": "attic",
+        "disko": "disko",
+        "flake-compat": "flake-compat_2",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "sops-nix": "sops-nix"
+      },
+      "locked": {
+        "lastModified": 1743119614,
+        "narHash": "sha256-Rx176Jy8V0nplbZRPbmWAKjUoQlmB9B6+ww3/thd6Q4=",
+        "ref": "main",
+        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "revCount": 68,
+        "type": "git",
+        "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
+      },
+      "original": {
+        "ref": "main",
+        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "type": "git",
+        "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "northwood-nixpkgs": "northwood-nixpkgs"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -241,17 +241,17 @@
         "sops-nix": "sops-nix"
       },
       "locked": {
-        "lastModified": 1743119614,
-        "narHash": "sha256-Rx176Jy8V0nplbZRPbmWAKjUoQlmB9B6+ww3/thd6Q4=",
+        "lastModified": 1743443442,
+        "narHash": "sha256-zn06aStEKlpgiaQsGTY/J1ZcNnSSdKB/T1UQwSnLrbM=",
         "ref": "main",
-        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
-        "revCount": 68,
+        "rev": "78340900e0862efaf0b2d23aa55a1155327cd78c",
+        "revCount": 75,
         "type": "git",
         "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
       },
       "original": {
         "ref": "main",
-        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "rev": "78340900e0862efaf0b2d23aa55a1155327cd78c",
         "type": "git",
         "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "A very basic flake for building altera linux";
+
+  inputs = {
+    northwood-nixpkgs.url = "git+ssh://git@github.com/Northwood-Space/northwood-nixpkgs?ref=main&rev=4388c8560e03ce7b45b74c49245a61d719a64fbe";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, northwood-nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = northwood-nixpkgs.legacyPackages.${system};
+        in {
+          devShells.default = import ./shell.nix {
+            inherit system pkgs;
+            # If you would like to use menuconfig or xconfig to configure your image,
+            # then comment out one of the following lines.
+            #
+            # By default, we do not want to pull in the dependencies these require.
+
+            # menuconfig = true;
+            # xconfig = true;
+          };
+        }
+      );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
 
             # menuconfig = true;
             # xconfig = true;
+            fit-generation = true;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A very basic flake for building altera linux";
 
   inputs = {
-    northwood-nixpkgs.url = "git+ssh://git@github.com/Northwood-Space/northwood-nixpkgs?ref=main&rev=4388c8560e03ce7b45b74c49245a61d719a64fbe";
+    northwood-nixpkgs.url = "git+ssh://git@github.com/Northwood-Space/northwood-nixpkgs?ref=main&rev=78340900e0862efaf0b2d23aa55a1155327cd78c";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/justfile
+++ b/justfile
@@ -18,7 +18,12 @@ clean:
 [group('Build')]
 link-config:
   ln -sf $NIX_CONFIGFILE .config
-  
+
+# Link the nix-build generated initrd to our local path
+[group('Build')]
+link-initrd:
+  ln -sf $INITRD initrd.zst
+
 # Configure linux kernel parameters via menuconfig. You will need to be in the shell with menuconfig = true; in the flake.nix
 [group('Build')]
 menuconfig:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,6 @@
-default: clean configure build
+# Display this message
+default:
+  @just --list
 
 # Build Linux Kernel Image for Northwood Beamformer
 [group('Build')]
@@ -12,11 +14,11 @@ clean:
   @make distclean
   @make mrproper
 
-# Configure Linux Kernel Image for Northwood Beamformer
+# Link the nix-build generated linux config to .config
 [group('Build')]
-configure:
-  runPhase configurePhase
-
+link-config:
+  ln $NIX_CONFIGFILE .config
+  
 # Configure linux kernel parameters via menuconfig. You will need to be in the shell with menuconfig = true; in the flake.nix
 [group('Build')]
 menuconfig:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,28 @@
+default: clean configure build
+
+# Build Linux Kernel Image for Northwood Beamformer
+[group('Build')]
+build:
+  make -j$(nproc) $makeFlags
+
+# Removes build artifacts and generated configuration files
+[group('Build')]
+clean:
+  @make clean
+  @make distclean
+  @make mrproper
+
+# Configure Linux Kernel Image for Northwood Beamformer
+[group('Build')]
+configure:
+  runPhase configurePhase
+
+# Configure linux kernel parameters via menuconfig. You will need to be in the shell with menuconfig = true; in the flake.nix
+[group('Build')]
+menuconfig:
+  make menuconfig
+
+# Configure linux kernel parameters via xconfig. You will need to be in the shell with xconfig = true; in the flake.nix
+[group('Build')]
+xconfig:
+  make xconfig

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ clean:
 # Link the nix-build generated linux config to .config
 [group('Build')]
 link-config:
-  ln $NIX_CONFIGFILE .config
+  ln -sf $NIX_CONFIGFILE .config
   
 # Configure linux kernel parameters via menuconfig. You will need to be in the shell with menuconfig = true; in the flake.nix
 [group('Build')]

--- a/justfile
+++ b/justfile
@@ -28,3 +28,12 @@ menuconfig:
 [group('Build')]
 xconfig:
   make xconfig
+
+# Build a Flatted uImage Tree (FIT) kernel. Requires Image, initrd.zst, and beamformer.dtb to be at the root.
+[group('Build')]
+fit-image:
+  #!/usr/bin/env bash
+
+  set -euox pipefail
+
+  mkimage -f $FIT_CONFIG kernel.itb

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ let
   #
   # This is why we choose to use overrideAttrs
   # https://ryantm.github.io/nixpkgs/using/overrides/#sec-pkg-overrideAttrs
+  configfile = pkgsCross.altera-linux.configfile;
   drv = pkgsCross.altera-linux.overrideAttrs(final: prev: {
     # give it a new name so we can differentiate between nix build derivations and nix shell roots
     pname = "northwood-altera-linux";
@@ -35,7 +36,14 @@ let
       menuconfigAttrs
       xconfigAttrs
     ];
-    modDirVersion = "6.6.22-ga8b714be34bc-dirty";
+    shellHook = ''
+      echo "================================================"
+      echo "==         Caveat Lector                      =="
+      echo "================================================"
+      echo ".config for the $NIX_BUILD located at ${configfile}"
+      echo "If you would like to use this, then run just link-config"
+    '';
+    NIX_CONFIGFILE=configfile;
   });
 in
 drv

--- a/shell.nix
+++ b/shell.nix
@@ -55,7 +55,7 @@ let
 
     '';
     NIX_CONFIGFILE=configfile;
-    INITRD=initrd;
+    INITRD="${initrd}/initrd.zst";
     FIT_CONFIG=fit-config;
   });
 in

--- a/shell.nix
+++ b/shell.nix
@@ -47,12 +47,17 @@ let
       echo "==         Caveat Lector                      =="
       echo "================================================"
       echo "This shell pulls in a few extraneous dependencies"
-      echo "The linux configfile is stored in $NIX_CONFIGFILE and can be copied locally using `just link-config`"
+      echo "The linux configfile is stored in $NIX_CONFIGFILE and can be copied locally using \"just link-config\""
+    '' + lib.strings.optionalString menuconfig ''
+      echo "You have menuconfig enabled in your build... Hurrah!"
+    '' + lib.strings.optionalString xconfig ''
+      echo "You have xconfig enabled in your build... Hurrah!"
     '' + lib.strings.optionalString fit-generation ''
       echo "Initrd stored in \$INITRD environment variable."
       echo "Fit Image stored in \$FIT_CONFIG"
       echo "See the buildPhase of northwood-nixpkgs/pkgs/machines/beamformer/generate-fit.nix for building image"
-
+    '' + lib.strings.optionalString (!(xconfig || menuconfig)) ''
+      echo "You have neither menuconfig nor xconfig enabled..."
     '';
     NIX_CONFIGFILE=configfile;
     INITRD="${initrd}/initrd.zst";

--- a/shell.nix
+++ b/shell.nix
@@ -30,6 +30,7 @@ let
   # https://ryantm.github.io/nixpkgs/using/overrides/#sec-pkg-overrideAttrs
   configfile = pkgsCross.altera-linux.configfile;
   initrd = if fit-generation then pkgsCross.beamformer.netbootRamdisk else "";
+  fit-config = if fit-generation then pkgsBuild.beamformer-fit-config else "";
   drv = pkgsCross.altera-linux.overrideAttrs(final: prev: {
     # give it a new name so we can differentiate between nix build derivations and nix shell roots
     pname = "northwood-altera-linux";
@@ -45,14 +46,17 @@ let
       echo "================================================"
       echo "==         Caveat Lector                      =="
       echo "================================================"
-      echo "This shell pulls in a few extraneous dependencies\n"
+      echo "This shell pulls in a few extraneous dependencies"
       echo "The linux configfile is stored in $NIX_CONFIGFILE and can be copied locally using `just link-config`"
     '' + lib.strings.optionalString fit-generation ''
       echo "Initrd stored in \$INITRD environment variable."
+      echo "Fit Image stored in \$FIT_CONFIG"
       echo "See the buildPhase of northwood-nixpkgs/pkgs/machines/beamformer/generate-fit.nix for building image"
+
     '';
     NIX_CONFIGFILE=configfile;
     INITRD=initrd;
+    FIT_CONFIG=fit-config;
   });
 in
 drv

--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,10 @@
 # Optionally add dependencies for xconfig and menu config 
 , menuconfig ? false
 , xconfig ? false
+, fit-generation ? false
 }:
 let
+  lib = pkgsBuild.lib;
   # If we are aarch64-linux, then we do not need a cross-toolchain.
   # Otherwise, grab the pkgsCross
   #
@@ -21,11 +23,13 @@ let
   pkgsBuild = pkgsCross.buildPackages;
   menuconfigAttrs = if menuconfig then [ pkgsBuild.pkg-config pkgsBuild.ncurses ] else [];
   xconfigAttrs = if xconfig then [ pkgsBuild.pkg-config pkgsBuild.qt5.qtbase ] else [];
+  fitGenerationAttrs = if fit-generation then [ pkgsBuild.zstd pkgsBuild.xz pkgsBuild.ubootTools ] else [];
   # We want to use the same build environment that our nix derivation uses but with some new friends.
   #
   # This is why we choose to use overrideAttrs
   # https://ryantm.github.io/nixpkgs/using/overrides/#sec-pkg-overrideAttrs
   configfile = pkgsCross.altera-linux.configfile;
+  initrd = if fit-generation then pkgsCross.beamformer.netbootRamdisk else "";
   drv = pkgsCross.altera-linux.overrideAttrs(final: prev: {
     # give it a new name so we can differentiate between nix build derivations and nix shell roots
     pname = "northwood-altera-linux";
@@ -35,15 +39,20 @@ let
       # add our optional inputs
       menuconfigAttrs
       xconfigAttrs
+      fitGenerationAttrs
     ];
     shellHook = ''
       echo "================================================"
       echo "==         Caveat Lector                      =="
       echo "================================================"
-      echo ".config for the $NIX_BUILD located at ${configfile}"
-      echo "If you would like to use this, then run just link-config"
+      echo "This shell pulls in a few extraneous dependencies\n"
+      echo "The linux configfile is stored in $NIX_CONFIGFILE and can be copied locally using `just link-config`"
+    '' + lib.strings.optionalString fit-generation ''
+      echo "Initrd stored in \$INITRD environment variable."
+      echo "See the buildPhase of northwood-nixpkgs/pkgs/machines/beamformer/generate-fit.nix for building image"
     '';
     NIX_CONFIGFILE=configfile;
+    INITRD=initrd;
   });
 in
 drv

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,41 @@
+{ pkgs ? import <nixpkgs> {}
+, target ? "aarch64-multiplatform"
+, system
+# Optionally add dependencies for xconfig and menu config 
+, menuconfig ? false
+, xconfig ? false
+}:
+let
+  # If we are aarch64-linux, then we do not need a cross-toolchain.
+  # Otherwise, grab the pkgsCross
+  #
+  # Notes on cross-compilation
+  # https://nixos.wiki/wiki/Cross_Compiling#Lazy_cross-compiling
+  # https://matthewbauer.us/blog/beginners-guide-to-cross.html
+  shouldCross = system == "aarch64-linux";
+  pkgsCross =
+    if shouldCross
+    then builtins.trace "using native pkgs" pkgs
+    else builtins.trace "using pkgsCross" pkgs.pkgsCross.${target};
+  # Even if we are cross-compiling we still want the pkg-config and friends for the machine we are building on, not building for.
+  pkgsBuild = pkgsCross.buildPackages;
+  menuconfigAttrs = if menuconfig then [ pkgsBuild.pkg-config pkgsBuild.ncurses ] else [];
+  xconfigAttrs = if xconfig then [ pkgsBuild.pkg-config pkgsBuild.qt5.qtbase ] else [];
+  # We want to use the same build environment that our nix derivation uses but with some new friends.
+  #
+  # This is why we choose to use overrideAttrs
+  # https://ryantm.github.io/nixpkgs/using/overrides/#sec-pkg-overrideAttrs
+  drv = pkgsCross.altera-linux.overrideAttrs(final: prev: {
+    # give it a new name so we can differentiate between nix build derivations and nix shell roots
+    pname = "northwood-altera-linux";
+    nativeBuildInputs = builtins.concatLists [
+      # our build tools for
+      prev.nativeBuildInputs
+      # add our optional inputs
+      menuconfigAttrs
+      xconfigAttrs
+    ];
+    modDirVersion = "6.6.22-ga8b714be34bc-dirty";
+  });
+in
+drv


### PR DESCRIPTION
Similar to https://github.com/Northwood-Space/u-boot-socfpga/pull/5 but for Linux builds.

```bash
northwood@system76-pc ~/d/c/n/linux-socfpga (devshell)> just
Available recipes:
    default     # Display this message

    [Build]
    build       # Build Linux Kernel Image for Northwood Beamformer
    clean       # Removes build artifacts and generated configuration files
    link-config # Link the nix-build generated linux config to .config
    menuconfig  # Configure linux kernel parameters via menuconfig. You will need to be in the shell with menuconfig = true; in the flake.nix
    xconfig     # Configure linux kernel parameters via xconfig. You will need to be in the shell with xconfig = true; in the flake.nix
northwood@system76-pc ~/d/c/n/linux-socfpga (devshell)> nix develop .#
trace: using pkgsCross
================================================
==         Caveat Lector                      ==
================================================
.config for the  located at /nix/store/lrm7xvyj9xn7lm9kk05mgrvc5yxw4fgd-linux-config-aarch64-unknown-linux-gnu-6.6.22
If you would like to use this, then run just link-config
```